### PR TITLE
Add BestofWeb.site to AI Directories list

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 
 - [Based Tools](https://www.basedtools.ai/) - The most Based AI Directory.
 - [Best AI Tools org](https://www.best-ai-tools.org/) - Find & Learn AI Tools with AI ChatBot + free Academy
+- [Best of Web](https://www.bestofweb.site) – Startup and founder directory. Easy and fast to submit, includes a free dofollow backlink.
 - [Beyond AI Tools](https://www.beyondaitools.com/) - AI tools, solutions, best practices, and more — all with multilingual support, aiming to foster AI adoption across the globe.
 - [Byblos AI](https://byblosai.com/) - Find AI tools and software using an AI search
 


### PR DESCRIPTION
This PR adds BestofWeb.site to the directory list.
Best of Web is a startup and founder directory where submission is easy and fast, and every approved listing includes a free dofollow backlink.