### PR TITLE
add ClaudePro.directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 
 ## C
 
+- [ClaudePro.directory](https://claudepro.directory/) - The unofficial home for Claude enthusiasts. Explore expert rules, browse powerful MCP servers, find specialized agents and commands, discover automation hooks, and connect with the community building the future of AI.
 - [Cloudbooklet AI](https://www.cloudbooklet.net/) - Cloudbooklet AI Tools.
 - [CogList AI](https://coglist.com/) - AI Agents/Tools Directory and List for Indie Hackers in Project Building.
 


### PR DESCRIPTION
Adding ClaudePro.directory, an open-source and completely free directory for all things Claude.