### PR TITLE
Add Tool Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - [Top Tools](https://www.toptools.ai/) - AI Tools Directory
 - [Tools](https://tools.so/) - Growing directory of the best AI tools on the internet.
 - [Tools Hub AI](https://toolshubai.com/) - Explore the best AI tools for every task
+- [Tool Directory](https://tooldirectory.ai/) - AI tool directory with 2,000+ tools, editorial reviews, side-by-side comparisons, and an AI graveyard tracking defunct tools.
 - [ThatsMyAI](https://thatsmy.ai/) - Discover the right AI Apps and Certifications for your needs
 - [The Next AI Tool](https://thenextaitool.com) - Discover over 43K AI tools across 80+ categories
 - [TrustList](https://www.trustlist.ai/) - Your Trusted A.I. Guide. Discover the A.I. solutions that simplify your daily tasks.


### PR DESCRIPTION
Adds **Tool Directory** (https://tooldirectory.ai/) to the directories list under the `T` section.

AI tool directory with 2,000+ tools, editorial reviews, side-by-side comparisons, and an AI graveyard tracking defunct tools. Single-line addition following the existing format.