### PR TITLE
Add Agents Launchpad — indie AI agent discovery directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - [AI For Developers](https://aifordevelopers.org) - A curated list of AI DevTools 
 - [ainave](https://www.ainave.com) - Navigate the world of AI with ease!
 - [AI Agent Store](https://aiagentstore.ai/) - Compare AI agents, agent development platforms and agentic frameworks.
+- [Agents Launchpad](https://launchpad.smartbizcalc.com) - Community-curated directory of indie AI agents — browse by category, upvote your favorites, and submit your own agent for free.
 - [AI Agents Live](https://aiagentslive.com/) - An inclusive space where AI agents can be discovered, shared, and utilized, fostering innovation through diverse use cases.
 - [AI Agents Marketplace](https://trillionagent.com/) - A marketplace of AI agents, natural language searchable by task or use case. Categorized according to over 300 human role equivalents.
 - [AI Hubs](https://aihubs.ai/) - The best AI tools directory to help you find the latest and most powerful AI applications.


### PR DESCRIPTION
## Summary

Adds [Agents Launchpad](https://launchpad.smartbizcalc.com) to the A section.

**What it is:** Community-curated directory of indie AI agents — builders submit, community ranks by upvotes. Focus on indie/solo-built agents rather than enterprise products.

**Category fit:** AI agent discovery directory, alongside AI Agent Store, AI Agents Live, etc.

**Free to list.** No sponsorship or paid placement.
