### PR TITLE
Add StackScan AI Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - [Selljam.ai](https://selljam.ai/) - Best AI tools and resources for online sellers and ecom pros.
 - [Show Me Best AI](https://showmebest.ai/) - Discover the best AI tools at ShowMeBestAI
 - [Submit AI Tools](https://submitaitools.org) - Unleash AI’s Potential Discover Tools, Drive Innovation
+- [StackScan AI Websites](https://www.stackscan.com/lists/ai-websites) - 2000+ most visited AI websites ranked by monthly traffic
 
 ## T
 


### PR DESCRIPTION
Adds StackScan AI Websites to the **S** section.

A ranked directory of 2,187 AI platforms, tools and services, ordered by estimated monthly traffic with monthly unique visitors shown per site. Drawn from 50M+ tracked domains and refreshed monthly.

Free to browse, no account needed.
