### PR TITLE
Add Plug to P section

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 
 ## P
 
+- [Plug](https://www.getplug.ai/?utm_source=github&utm_medium=directory&utm_campaign=ai-directories) - Track where AI answers cite you across ChatGPT, Perplexity & Google AI Overviews
 - [PoweredbyAI](https://poweredbyai.app) - AI TOOLS & PROMPTS!
 - [Productivity Tools](https://productivity.directory) - A curated productivity directory
 


### PR DESCRIPTION
Adds **Plug** ([getplug.ai](https://www.getplug.ai/)) to the P section, placed alphabetically (before PoweredbyAI).

Plug is an off-site AI citation tracking tool — it shows brands which off-site content (Reddit threads, reviews, creator posts, etc.) gets cited by AI answer engines like ChatGPT, Perplexity, and Google AI Overviews.

One line added, following the existing `- [Name](url) - Description` format.