### PR TITLE
Add AI Tools Radar to AI directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - [AI Tools Corner](https://aitoolscorner.com/) - Collection of best AI Tools,
 - [AI Tools Directory](https://aidirectory.wiki/) - Curated list of AI tools
 - [AI Tools Pin](https://aitoolspin.com/) - The best AI tools by category
+- [AI Tools Radar](https://github.com/ppop123/ai-tools-radar) - Local-first dashboard for exploring AI-tool traffic estimates, growth trends, and dofollow backlink-source snapshots.
 - [AISuperSmart](https://www.aisupersmart.com/ai-tools-directory/) - 1500+ Ai Tools Which Update's Daily And Provide Ai News to World
 - [AI-Tools Directory](https://ai-tools.directory) - A directory of AI tools curated by AI itself
 - [AI Tools Guru](https://aitoolguru.com/) - THE LARGEST AI TOOLS DIRECTORY
@@ -260,4 +261,3 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 # Add Yours
 
 Feel Free to add your AI Directory To this list
-

--- a/README.md
+++ b/README.md
@@ -261,3 +261,4 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 # Add Yours
 
 Feel Free to add your AI Directory To this list
+


### PR DESCRIPTION
## Summary

Adds [AI Tools Radar](https://github.com/ppop123/ai-tools-radar) to the A section of the directory list.

- Public GitHub Pages demo: https://ppop123.github.io/ai-tools-radar/
- Open-source, local-first dashboard for exploring AI-tool traffic estimates, growth trends, and backlink-source snapshots.
- The repository's code is MIT-licensed; its `data/` directory contains third-party SimilarWeb/Semrush estimate snapshots for research use and is not represented as MIT-licensed data.
- Per the project README, per-domain backlink details are limited to the top 100 entries, not a complete backlink export.
- The repository and Pages demo were reachable (HTTP 200) when this PR was prepared.

Disclosure: this is a first-party self-submission by the project maintainer. The entry and claims were reviewed manually after AI-assisted drafting.
