### PR TITLE
Add Siteefy to AI directories list

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - [SearchAiDirectory](https://searchaidirectory.com/) - Find the best AI tools to solve your problems.
 - [Selljam.ai](https://selljam.ai/) - Best AI tools and resources for online sellers and ecom pros.
 - [Show Me Best AI](https://showmebest.ai/) - Discover the best AI tools at ShowMeBestAI
+- [Siteefy](https://siteefy.com/) - Discover and compare AI tools, SaaS products, and digital services by category and use case.
 - [Submit AI Tools](https://submitaitools.org) - Unleash AI’s Potential Discover Tools, Drive Innovation
 
 ## T


### PR DESCRIPTION
- Add Siteefy under the S section of the directory index.\n- Describe its verified AI tool, SaaS, and digital-service discovery scope.\n- Link directly to the official Siteefy homepage.