### PR TITLE
Add AI Nexus (myaiexp.com)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 - [AI Agents Marketplace](https://trillionagent.com/) - A marketplace of AI agents, natural language searchable by task or use case. Categorized according to over 300 human role equivalents.
 - [AI Hubs](https://aihubs.ai/) - The best AI tools directory to help you find the latest and most powerful AI applications.
 - [AI Hunt List](https://aihuntlist.com/) - Discover The Best AI Products & Tools. 3000+ AI products and 200+ categories in the best AI products directory.
-- [AI Library](https://www.theailibrary.co/) - A powerful AI Tools Directory with 500+ tools for every need, from productivity to creativity. 
+- [AI Library](https://www.theailibrary.co/) - A powerful AI Tools Directory with 500+ tools for every need, from productivity to creativity.
+- [AI Nexus](https://www.myaiexp.com) - Trilingual (EN/ZH/JP) curated directory of AI developer tools, models, and agent skills. 
 - [AiMatchPro](https://aimatch.pro/) -Directory making it easy to find an ai tool for your specific usecase by matching a stack of tools with a search query.
 - [AI PEDIA HUB](https://aipediahub.com/) - THE LARGEST AI TOOLS DIRECTORY, UPDATED DAILY.
 - [AI Pulse](https://www.aipulse.fyi) - Your trusted source for in-depth reviews of the latest AI tools and technologies.


### PR DESCRIPTION
[38;2;248;248;242mAdd [AI Nexus](https://www.myaiexp.com) (AI 星图): a trilingual (EN/ZH/JP) curated directory of AI developer tools, models, and agent skills.[0m

[38;2;248;248;242mPlaced under **A** next to other AI directory listings.[0m