### PR TITLE
Add WhatAreYouBuilding.AI to W section

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Sponsors: *[Altern AI](https://altern.ai)*, *[Productivity Directory](https://pr
 ## W
 
 - [Webspot](https://webspot.app/) - Find the Best Websites on the Internet in 2025
+- [WhatAreYouBuilding.AI](https://whatareyoubuilding.ai) - Free worldwide directory of what independent builders are shipping — AI, SaaS and dev tools (by country, category, funding stage). Free listing, dofollow, live badge; MCP for agents at /mcp.
 - [WhatstheBigData.com](https://whatsthebigdata.com/ai-tools/) - Browse the top AI tools
 
 ## Y


### PR DESCRIPTION
## Summary
Adds [WhatAreYouBuilding.AI](https://whatareyoubuilding.ai) under **W**.

Free worldwide directory of what independent builders are shipping (AI, SaaS, and dev tools), filterable by country, category, and funding stage. Free listing, dofollow, live badge; MCP endpoint for agents at `/mcp`.

## Checklist
- [x] Not already listed
- [x] Placed alphabetically in `## W`
- [x] Active site / accepts listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqGP9PJPjNM4ki2FywWGHe